### PR TITLE
SDK-753 model determinism for 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <simudyne.version>2.1.0</simudyne.version>
+        <simudyne.version>2.2.0</simudyne.version>
     </properties>
 
     <repositories>

--- a/src/main/java/org/example/models/advanced3/Distribution.java
+++ b/src/main/java/org/example/models/advanced3/Distribution.java
@@ -24,6 +24,8 @@ class Distribution {
 
   private double[] samples;
 
+  private static final long SEED = 9;
+
   Distribution() {
     List<BucketInfo> bucketInfo = new ArrayList<>();
     bucketInfo.add(new BucketInfo(2200, 2800, 0.000832961));
@@ -58,6 +60,7 @@ class Distribution {
 
   EmpiricalDistribution getIncomeDistribution() {
     EmpiricalDistribution empiricalDistribution = new EmpiricalDistribution();
+    empiricalDistribution.reSeed(SEED);
     empiricalDistribution.load(samples);
     return empiricalDistribution;
   }

--- a/src/main/java/org/example/models/trading/TradingModel.java
+++ b/src/main/java/org/example/models/trading/TradingModel.java
@@ -34,7 +34,8 @@ public class TradingModel extends AgentBasedModel<TradingModel.Globals> {
 
   @Override
   public void init() {
-      getGlobals().informationSignal = getContext().getPRNG().generator.nextGaussian()*getGlobals().volatilityInfo;
+    getGlobals().informationSignal =
+        getContext().getPRNG().generator.nextGaussian() * getGlobals().volatilityInfo;
   }
 
   @Override
@@ -52,8 +53,8 @@ public class TradingModel extends AgentBasedModel<TradingModel.Globals> {
   public void step() {
     super.step();
 
-    getGlobals().informationSignal = getContext().getPRNG().generator.nextGaussian()*getGlobals().volatilityInfo;
-
+    getGlobals().informationSignal =
+        getContext().getPRNG().generator.nextGaussian() * getGlobals().volatilityInfo;
 
     run(Trader.processInformation(), Market.calcPriceImpact(), Trader.updateThreshold());
   }


### PR DESCRIPTION
Updates the model against 2.2.0.preview.2. This uses Model#init to set globals using the models SeededRandom

We probablly want to reimplement the Distribution#getIncomeDistribution using work carried out in https://simudyne.atlassian.net/browse/SDK-34.